### PR TITLE
Add CSV and PDF importers

### DIFF
--- a/parser/__init__.py
+++ b/parser/__init__.py
@@ -1,0 +1,6 @@
+"""Parsers for importing bank statements."""
+
+from .csv_importer import parse_csv
+from .pdf_importer import parse_pdf
+
+__all__ = ["parse_csv", "parse_pdf"]

--- a/parser/csv_importer.py
+++ b/parser/csv_importer.py
@@ -1,0 +1,76 @@
+"""CSV importer for bank statements."""
+
+from __future__ import annotations
+
+import csv
+import os
+from datetime import datetime
+from typing import List, Dict, Any, Optional
+
+import pandas as pd
+
+ARCHIVE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "archived")
+
+
+def _find_column(columns: List[str], names: List[str]) -> Optional[str]:
+    for name in names:
+        if name in columns:
+            return name
+    return None
+
+
+def parse_csv(file_path: str) -> List[Dict[str, Any]]:
+    """Parse a CSV bank statement and return standardized transactions."""
+    df = pd.read_csv(file_path)
+    df.columns = [c.strip().lower() for c in df.columns]
+
+    date_col = _find_column(
+        df.columns.tolist(),
+        ["date", "transaction date", "posted date", "created"],
+    )
+    desc_col = _find_column(
+        df.columns.tolist(),
+        ["description", "memo", "reference", "details", "transaction description"],
+    )
+    amount_col = _find_column(df.columns.tolist(), ["amount", "value"])
+
+    if amount_col is None:
+        credit_col = _find_column(
+            df.columns.tolist(), ["money in", "credit amount", "paid in", "credit"]
+        )
+        debit_col = _find_column(
+            df.columns.tolist(), ["money out", "debit amount", "paid out", "debit"]
+        )
+        if credit_col or debit_col:
+            credit = df.get(credit_col, 0).fillna(0)
+            debit = df.get(debit_col, 0).fillna(0)
+            df["amount"] = credit - debit
+            amount_col = "amount"
+
+    if date_col is None or desc_col is None or amount_col is None:
+        raise ValueError("Required columns not found in CSV")
+
+    transactions: List[Dict[str, Any]] = []
+    for _, row in df.iterrows():
+        date = str(row[date_col]).strip()
+        desc = str(row[desc_col]).strip()
+        amt_raw = str(row[amount_col]).replace(",", "").replace("$", "")
+        try:
+            amount = float(amt_raw)
+        except ValueError:
+            continue
+        transactions.append({"date": date, "description": desc, "amount": amount})
+
+    _archive(file_path)
+    return transactions
+
+
+def _archive(file_path: str) -> None:
+    os.makedirs(ARCHIVE_DIR, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    base = os.path.basename(file_path)
+    archived_path = os.path.join(ARCHIVE_DIR, f"{ts}_{base}")
+    os.replace(file_path, archived_path)
+
+
+__all__ = ["parse_csv"]

--- a/parser/pdf_importer.py
+++ b/parser/pdf_importer.py
@@ -1,0 +1,50 @@
+"""PDF importer for bank statements using pdfplumber."""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime
+from typing import List, Dict, Any
+
+import pdfplumber
+
+ARCHIVE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "archived")
+
+PATTERN = re.compile(
+    r"(?P<date>\d{1,2}[/-]\d{1,2}[/-]\d{2,4})\s+(?P<desc>.*?)\s+(?P<amt>-?\$?[\d,]+\.\d{2})$"
+)
+
+
+def parse_pdf(file_path: str) -> List[Dict[str, Any]]:
+    """Parse a PDF bank statement and return standardized transactions."""
+    transactions: List[Dict[str, Any]] = []
+    with pdfplumber.open(file_path) as pdf:
+        for page in pdf.pages:
+            text = page.extract_text() or ""
+            for line in text.split("\n"):
+                match = PATTERN.search(line.strip())
+                if not match:
+                    continue
+                date = match.group("date")
+                desc = match.group("desc").strip()
+                amt_raw = match.group("amt").replace("$", "").replace(",", "")
+                try:
+                    amount = float(amt_raw)
+                except ValueError:
+                    continue
+                transactions.append({"date": date, "description": desc, "amount": amount})
+
+    _archive(file_path)
+    return transactions
+
+
+def _archive(file_path: str) -> None:
+    os.makedirs(ARCHIVE_DIR, exist_ok=True)
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    base = os.path.basename(file_path)
+    archived_path = os.path.join(ARCHIVE_DIR, f"{ts}_{base}")
+    os.replace(file_path, archived_path)
+
+
+__all__ = ["parse_pdf"]


### PR DESCRIPTION
## Summary
- implement `parser/csv_importer.py` for parsing common bank CSVs
- implement `parser/pdf_importer.py` for parsing PDF statements
- expose both importers from `parser/__init__.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862ca791af083318a78963496124394