### PR TITLE
Add summary tab with cashflow overview

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,4 +1,6 @@
 from PyQt5 import QtWidgets, QtCore
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -59,15 +61,36 @@ class MainWindow(QtWidgets.QMainWindow):
         # Stacked widget for pages
         self.stack = QtWidgets.QStackedWidget()
         right_layout.addWidget(self.stack)
-        self.tables = []
-        for _ in self.tabs:
-            table = QtWidgets.QTableWidget(0, 4)
-            table.setHorizontalHeaderLabels(
-                ["Date", "Description", "Category", "Amount"]
-            )
-            table.horizontalHeader().setStretchLastSection(True)
-            self.stack.addWidget(table)
-            self.tables.append(table)
+
+        self.tables = []  # transaction tables for Income/Expenses/Credit Card
+        for tab in self.tabs:
+            if tab == "Summary":
+                summary_widget = QtWidgets.QWidget()
+                summary_layout = QtWidgets.QVBoxLayout(summary_widget)
+                self.summary_table = QtWidgets.QTableWidget(0, 3)
+                self.summary_table.setHorizontalHeaderLabels(
+                    ["Category", "Income", "Expense"]
+                )
+                self.summary_table.horizontalHeader().setStretchLastSection(True)
+                summary_layout.addWidget(self.summary_table)
+
+                self.net_label = QtWidgets.QLabel("Net Cashflow: 0.00")
+                summary_layout.addWidget(self.net_label)
+
+                self.figure = Figure(figsize=(5, 3))
+                self.canvas = FigureCanvas(self.figure)
+                summary_layout.addWidget(self.canvas)
+
+                self.stack.addWidget(summary_widget)
+                self.summary_widget = summary_widget
+            else:
+                table = QtWidgets.QTableWidget(0, 4)
+                table.setHorizontalHeaderLabels(
+                    ["Date", "Description", "Category", "Amount"]
+                )
+                table.horizontalHeader().setStretchLastSection(True)
+                self.stack.addWidget(table)
+                self.tables.append(table)
 
         # Bottom action buttons
         button_widget = QtWidgets.QWidget()
@@ -108,6 +131,60 @@ class MainWindow(QtWidgets.QMainWindow):
                     [date_item, desc_item, cat_item, amt_item]
                 ):
                     table.setItem(i, col, item)
+
+        self._update_summary()
+
+    def _update_summary(self) -> None:
+        """Update the summary table and chart."""
+        totals = {}
+        # First table corresponds to Income
+        if self.tables:
+            income_table = self.tables[0]
+            for row in range(income_table.rowCount()):
+                category = income_table.item(row, 2).text()
+                amount = float(income_table.item(row, 3).text())
+                totals.setdefault(category, {"income": 0.0, "expense": 0.0})
+                totals[category]["income"] += amount
+
+        # Remaining tables are expenses
+        for table in self.tables[1:]:
+            for row in range(table.rowCount()):
+                category = table.item(row, 2).text()
+                amount = float(table.item(row, 3).text())
+                totals.setdefault(category, {"income": 0.0, "expense": 0.0})
+                totals[category]["expense"] += amount
+
+        self.summary_table.setRowCount(0)
+        categories = sorted(totals.keys())
+        for i, cat in enumerate(categories):
+            self.summary_table.insertRow(i)
+            self.summary_table.setItem(i, 0, QtWidgets.QTableWidgetItem(cat))
+            self.summary_table.setItem(
+                i, 1, QtWidgets.QTableWidgetItem(f"{totals[cat]['income']:.2f}")
+            )
+            self.summary_table.setItem(
+                i, 2, QtWidgets.QTableWidgetItem(f"{totals[cat]['expense']:.2f}")
+            )
+
+        total_income = sum(v["income"] for v in totals.values())
+        total_expense = sum(v["expense"] for v in totals.values())
+        net = total_income - total_expense
+        self.net_label.setText(f"Net Cashflow: {net:.2f}")
+
+        # Update bar chart
+        self.figure.clear()
+        ax = self.figure.add_subplot(111)
+        x = range(len(categories))
+        incomes = [totals[c]["income"] for c in categories]
+        expenses = [totals[c]["expense"] for c in categories]
+        ax.bar(x, incomes, width=0.4, label="Income", align="edge")
+        ax.bar([i + 0.4 for i in x], expenses, width=0.4, label="Expense", align="edge")
+        ax.set_xticks([i + 0.2 for i in x])
+        ax.set_xticklabels(categories, rotation=45, ha="right")
+        ax.legend()
+        ax.set_ylabel("Amount")
+        self.figure.tight_layout()
+        self.canvas.draw()
 
 
 __all__ = ["MainWindow"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pdfplumber
 sqlite3
 openai
 python-dotenv
+matplotlib


### PR DESCRIPTION
## Summary
- set up matplotlib dependency
- create Summary tab UI with totals table and bar chart
- compute monthly totals for income and expense categories
- display net cashflow for the selected month

## Testing
- `python -m py_compile gui/main_window.py gui/login_window.py logic/categoriser.py logic/month_manager.py parser/csv_importer.py parser/pdf_importer.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6862d1e5aa9c83318efe67f7681c9e75