### PR TITLE
Archive statements and log imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project is a desktop financial analysis tool built with PyQt and SQLite. It
 - `parser/` - CSV and PDF parsers
 - `logic/` - classification and transaction processing
 - `archived/` - processed statement files
+- `import_logs` table tracks archived imports
 - `main.py` - application entry point
 
 ## Login
@@ -27,3 +28,8 @@ Install the required dependencies and run the application:
 pip install -r requirements.txt
 python main.py
 ```
+
+When a CSV or PDF statement is imported, the original file is moved to the
+`archived/` directory and renamed with the import date, for example
+`statement_Starling_2023-03-01.csv`. Each archived import is recorded in the
+`import_logs` table.

--- a/parser/pdf_importer.py
+++ b/parser/pdf_importer.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import os
 import re
+import sqlite3
 from datetime import datetime
 from typing import List, Dict, Any
 
 import pdfplumber
 
 ARCHIVE_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "archived")
+DB_PATH = os.path.join(os.path.dirname(os.path.dirname(__file__)), "data", "finance.db")
 
 PATTERN = re.compile(
     r"(?P<date>\d{1,2}[/-]\d{1,2}[/-]\d{2,4})\s+(?P<desc>.*?)\s+(?P<amt>-?\$?[\d,]+\.\d{2})$"
@@ -35,16 +37,29 @@ def parse_pdf(file_path: str) -> List[Dict[str, Any]]:
                     continue
                 transactions.append({"date": date, "description": desc, "amount": amount})
 
-    _archive(file_path)
+    _archive(file_path, "pdf")
     return transactions
 
 
-def _archive(file_path: str) -> None:
+def _archive(file_path: str, file_type: str) -> None:
     os.makedirs(ARCHIVE_DIR, exist_ok=True)
-    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    ts = datetime.now().strftime("%Y-%m-%d")
     base = os.path.basename(file_path)
-    archived_path = os.path.join(ARCHIVE_DIR, f"{ts}_{base}")
+    name, ext = os.path.splitext(base)
+    archived_name = f"{name}_{ts}{ext}"
+    archived_path = os.path.join(ARCHIVE_DIR, archived_name)
     os.replace(file_path, archived_path)
+
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS import_logs (id INTEGER PRIMARY KEY, file_name TEXT, date TEXT, type TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO import_logs (file_name, date, type) VALUES (?, ?, ?)",
+        (archived_name, ts, file_type),
+    )
+    conn.commit()
+    conn.close()
 
 
 __all__ = ["parse_pdf"]

--- a/schema.sql
+++ b/schema.sql
@@ -39,3 +39,11 @@ CREATE TABLE IF NOT EXISTS mappings (
     FOREIGN KEY(category_id) REFERENCES categories(id)
 );
 
+-- Table for archived import logs
+CREATE TABLE IF NOT EXISTS import_logs (
+    id INTEGER PRIMARY KEY,
+    file_name TEXT NOT NULL,
+    date TEXT NOT NULL,
+    type TEXT NOT NULL
+);
+


### PR DESCRIPTION
## Summary
- rename processed CSV/PDF statements with a date suffix
- log archived file imports in new `import_logs` table
- update schema and documentation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862d650bdb08331b78274255665399d