### PR TITLE
Add monthly tabbed layout

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -2,5 +2,6 @@
 
 from .main_window import MainWindow
 from .login_window import LoginWindow
+from .monthly_tabbed_window import MonthlyTabbedWindow
 
-__all__ = ["MainWindow", "LoginWindow"]
+__all__ = ["MainWindow", "LoginWindow", "MonthlyTabbedWindow"]

--- a/gui/login_window.py
+++ b/gui/login_window.py
@@ -3,6 +3,7 @@ import hashlib
 from dotenv import dotenv_values
 
 from .main_window import MainWindow
+from .monthly_tabbed_window import MonthlyTabbedWindow
 
 
 class LoginWindow(QtWidgets.QWidget):
@@ -35,7 +36,7 @@ class LoginWindow(QtWidgets.QWidget):
     def check_password(self):
         password = self.password_edit.text()
         if hashlib.sha256(password.encode()).hexdigest() == self.password_hash:
-            self.main_window = MainWindow()
+            self.main_window = MonthlyTabbedWindow()
             self.main_window.show()
             self.close()
         else:

--- a/gui/monthly_tabbed_window.py
+++ b/gui/monthly_tabbed_window.py
@@ -1,0 +1,79 @@
+from PyQt5 import QtWidgets, QtCore
+
+
+class TableSection(QtWidgets.QGroupBox):
+    """A group box containing a transaction table and total label."""
+
+    def __init__(self, title: str) -> None:
+        super().__init__(title)
+        layout = QtWidgets.QVBoxLayout(self)
+
+        self.table = QtWidgets.QTableWidget(0, 5)
+        self.table.setHorizontalHeaderLabels(
+            ["Date", "Description", "Amount", "Category", "Notes"]
+        )
+        self.table.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(self.table)
+
+        self.total_label = QtWidgets.QLabel("Total: 0.00")
+        layout.addWidget(self.total_label, alignment=QtCore.Qt.AlignRight)
+
+        self.table.itemChanged.connect(self.update_total)
+
+    def update_total(self) -> None:
+        """Recalculate the total for the Amount column."""
+        total = 0.0
+        for row in range(self.table.rowCount()):
+            item = self.table.item(row, 2)
+            if item is None:
+                continue
+            try:
+                total += float(item.text())
+            except (TypeError, ValueError):
+                pass
+        self.total_label.setText(f"Total: {total:.2f}")
+
+
+class MonthlyTab(QtWidgets.QWidget):
+    """Widget representing a single month's data."""
+
+    SECTION_TITLES = [
+        "Income Table",
+        "Expenses Table",
+        "Credit Card Transactions",
+        "Monthly Summary",
+    ]
+
+    def __init__(self, month_name: str) -> None:
+        super().__init__()
+        layout = QtWidgets.QVBoxLayout(self)
+
+        self.sections = []
+        for title in self.SECTION_TITLES:
+            section = TableSection(title)
+            layout.addWidget(section)
+            self.sections.append(section)
+
+        layout.addStretch(1)
+
+
+class MonthlyTabbedWindow(QtWidgets.QMainWindow):
+    """Main window showing each month as a tab."""
+
+    def __init__(self, months=None) -> None:
+        super().__init__()
+        self.setWindowTitle("Personal Financial Analysis")
+        self.resize(1000, 700)
+        months = months or ["March 2024"]
+        self._setup_ui(months)
+
+    def _setup_ui(self, months) -> None:
+        self.tabs = QtWidgets.QTabWidget()
+        self.setCentralWidget(self.tabs)
+
+        for month in months:
+            tab = MonthlyTab(month)
+            self.tabs.addTab(tab, month)
+
+
+__all__ = ["MonthlyTabbedWindow", "MonthlyTab", "TableSection"]


### PR DESCRIPTION
## Summary
- create `MonthlyTabbedWindow` with QTabWidget month tabs
- export new window class in `gui.__init__`
- launch new tabbed window after login

## Testing
- `python -m py_compile gui/monthly_tabbed_window.py gui/login_window.py gui/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6862e591b24c8331a0d18147fc8c5054