### PR TITLE
Track last classified row separator

### DIFF
--- a/gui/monthly_tabbed_window.py
+++ b/gui/monthly_tabbed_window.py
@@ -2,6 +2,8 @@ from PyQt5 import QtWidgets, QtCore, QtGui
 
 # Custom role used to store whether a row is marked as recurring
 IS_RECURRING_ROLE = QtCore.Qt.UserRole + 1
+# Role used to flag the separator row that indicates the last classified point
+SEPARATOR_ROLE = QtCore.Qt.UserRole + 2
 
 
 class TableSection(QtWidgets.QGroupBox):
@@ -22,6 +24,10 @@ class TableSection(QtWidgets.QGroupBox):
         layout.addWidget(self.total_label, alignment=QtCore.Qt.AlignRight)
 
         self.table.itemChanged.connect(self.update_total)
+
+        # Track the row index of the last classified transaction
+        self.last_classified_row: int = -1
+        self._separator_row: int | None = None
 
     # ------------------------------------------------------------------
     # Recurring row helpers
@@ -45,10 +51,40 @@ class TableSection(QtWidgets.QGroupBox):
             current = bool(first_item.data(IS_RECURRING_ROLE)) if first_item else False
             self.set_row_recurring(row, not current)
 
+    # ------------------------------------------------------------------
+    # Classification helpers
+    # ------------------------------------------------------------------
+    def set_last_classified_row(self, row: int) -> None:
+        """Update the last classified row index and redraw the separator."""
+        self.last_classified_row = max(-1, min(row, self.table.rowCount() - 1))
+        self._draw_separator()
+
+    def _draw_separator(self) -> None:
+        """Insert a grey separator row above the first unclassified entry."""
+        if self._separator_row is not None:
+            self.table.removeRow(self._separator_row)
+            self._separator_row = None
+
+        insert_at = self.last_classified_row + 1
+        insert_at = max(0, min(insert_at, self.table.rowCount()))
+        self.table.insertRow(insert_at)
+        for col in range(self.table.columnCount()):
+            item = QtWidgets.QTableWidgetItem()
+            item.setFlags(QtCore.Qt.NoItemFlags)
+            item.setBackground(QtGui.QColor("#d0d0d0"))
+            item.setData(SEPARATOR_ROLE, True)
+            self.table.setItem(insert_at, col, item)
+        self.table.setRowHeight(insert_at, 4)
+        self._separator_row = insert_at
+
     def update_total(self) -> None:
         """Recalculate the total for the Amount column."""
         total = 0.0
         for row in range(self.table.rowCount()):
+            # Skip the grey separator row
+            first = self.table.item(row, 0)
+            if first and first.data(SEPARATOR_ROLE):
+                continue
             item = self.table.item(row, 2)
             if item is None:
                 continue
@@ -78,6 +114,8 @@ class MonthlyTab(QtWidgets.QWidget):
             section = TableSection(title)
             layout.addWidget(section)
             self.sections.append(section)
+            # Show a separator at the top by default
+            section.set_last_classified_row(-1)
 
         layout.addStretch(1)
 


### PR DESCRIPTION
## Summary
- add helper to show separator rows for the last classified point
- insert the separator for each table in MonthlyTab

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e8f596c08331b1befa7ab8b5a233