### PR TITLE
Enable keyboard navigation

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -3,5 +3,6 @@
 from .main_window import MainWindow
 from .login_window import LoginWindow
 from .monthly_tabbed_window import MonthlyTabbedWindow
+from .navigation_table_widget import NavigationTableWidget
 
-__all__ = ["MainWindow", "LoginWindow", "MonthlyTabbedWindow"]
+__all__ = ["MainWindow", "LoginWindow", "MonthlyTabbedWindow", "NavigationTableWidget"]

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,4 +1,5 @@
 from PyQt5 import QtWidgets, QtCore, QtGui
+from .navigation_table_widget import NavigationTableWidget
 
 # Custom role used to store whether a transaction is recurring
 IS_RECURRING_ROLE = QtCore.Qt.UserRole + 1
@@ -73,7 +74,7 @@ class MainWindow(QtWidgets.QMainWindow):
             if tab == "Summary":
                 summary_widget = QtWidgets.QWidget()
                 summary_layout = QtWidgets.QVBoxLayout(summary_widget)
-                self.summary_table = QtWidgets.QTableWidget(0, 3)
+                self.summary_table = NavigationTableWidget(0, 3)
                 self.summary_table.setHorizontalHeaderLabels(
                     ["Category", "Income", "Expense"]
                 )
@@ -92,7 +93,7 @@ class MainWindow(QtWidgets.QMainWindow):
             elif tab == "Admin":
                 admin_widget = QtWidgets.QWidget()
                 admin_layout = QtWidgets.QVBoxLayout(admin_widget)
-                self.mapping_table = QtWidgets.QTableWidget(0, 3)
+                self.mapping_table = NavigationTableWidget(0, 3)
                 self.mapping_table.setHorizontalHeaderLabels(
                     ["Keyword", "Category", "Last Used"]
                 )
@@ -121,7 +122,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 page = QtWidgets.QWidget()
                 page_layout = QtWidgets.QVBoxLayout(page)
 
-                table = QtWidgets.QTableWidget(0, 4)
+                table = NavigationTableWidget(0, 4)
                 table.setHorizontalHeaderLabels(
                     ["Date", "Description", "Category", "Amount"]
                 )

--- a/gui/monthly_tabbed_window.py
+++ b/gui/monthly_tabbed_window.py
@@ -1,4 +1,5 @@
 from PyQt5 import QtWidgets, QtCore, QtGui
+from .navigation_table_widget import NavigationTableWidget
 from datetime import datetime
 
 # Custom role used to store whether a row is marked as recurring
@@ -14,7 +15,7 @@ class TableSection(QtWidgets.QGroupBox):
         super().__init__(title)
         layout = QtWidgets.QVBoxLayout(self)
 
-        self.table = QtWidgets.QTableWidget(0, 5)
+        self.table = NavigationTableWidget(0, 5)
         self.table.setHorizontalHeaderLabels(
             ["Date", "Description", "Amount", "Category", "Notes"]
         )

--- a/gui/navigation_table_widget.py
+++ b/gui/navigation_table_widget.py
@@ -1,0 +1,62 @@
+from PyQt5 import QtWidgets, QtCore, QtGui
+
+
+class NavigationTableWidget(QtWidgets.QTableWidget):
+    """QTableWidget with simple keyboard navigation helpers."""
+
+    def keyPressEvent(self, event: QtGui.QKeyEvent) -> None:  # type: ignore[name-defined]
+        key = event.key()
+        row = self.currentRow()
+        col = self.currentColumn()
+
+        if key in (QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter):
+            if self.state() == QtWidgets.QAbstractItemView.EditingState:
+                self.closePersistentEditor(self.currentItem())
+            if row < self.rowCount() - 1:
+                self.setCurrentCell(row + 1, col)
+            event.accept()
+            return
+
+        if key == QtCore.Qt.Key_Escape and self.state() == QtWidgets.QAbstractItemView.EditingState:
+            self.closePersistentEditor(self.currentItem())
+            event.accept()
+            return
+
+        if key == QtCore.Qt.Key_Tab:
+            if self.state() == QtWidgets.QAbstractItemView.EditingState:
+                self.closePersistentEditor(self.currentItem())
+            r, c = row, col + 1
+            while r < self.rowCount():
+                while c < self.columnCount():
+                    item = self.item(r, c)
+                    if not item or not (item.flags() & QtCore.Qt.ItemIsEditable):
+                        c += 1
+                        continue
+                    self.setCurrentCell(r, c)
+                    event.accept()
+                    return
+                r += 1
+                c = 0
+            event.accept()
+            return
+
+        if key in (
+            QtCore.Qt.Key_Up,
+            QtCore.Qt.Key_Down,
+            QtCore.Qt.Key_Left,
+            QtCore.Qt.Key_Right,
+        ):
+            if self.state() == QtWidgets.QAbstractItemView.EditingState:
+                self.closePersistentEditor(self.currentItem())
+            if key == QtCore.Qt.Key_Up and row > 0:
+                self.setCurrentCell(row - 1, col)
+            elif key == QtCore.Qt.Key_Down and row < self.rowCount() - 1:
+                self.setCurrentCell(row + 1, col)
+            elif key == QtCore.Qt.Key_Left and col > 0:
+                self.setCurrentCell(row, col - 1)
+            elif key == QtCore.Qt.Key_Right and col < self.columnCount() - 1:
+                self.setCurrentCell(row, col + 1)
+            event.accept()
+            return
+
+        super().keyPressEvent(event)


### PR DESCRIPTION
## Summary
- add a NavigationTableWidget for simple keyboard navigation
- use NavigationTableWidget in main and monthly windows
- expose NavigationTableWidget from gui package

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6862eee9fb148331b62ab70804151342