### PR TITLE
Add row tooltips with classification info

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -1,5 +1,9 @@
 from PyQt5 import QtWidgets, QtCore, QtGui
-from .navigation_table_widget import NavigationTableWidget
+from .navigation_table_widget import (
+    NavigationTableWidget,
+    ORIGINAL_DESC_ROLE,
+    CATEGORY_METHOD_ROLE,
+)
 
 # Custom role used to store whether a transaction is recurring
 IS_RECURRING_ROLE = QtCore.Qt.UserRole + 1
@@ -176,7 +180,9 @@ class MainWindow(QtWidgets.QMainWindow):
                 desc_item = QtWidgets.QTableWidgetItem(
                     f"{month} transaction {i+1}"
                 )
+                desc_item.setData(ORIGINAL_DESC_ROLE, desc_item.text())
                 cat_item = QtWidgets.QTableWidgetItem("Misc")
+                cat_item.setData(CATEGORY_METHOD_ROLE, "manual")
                 amt_item = QtWidgets.QTableWidgetItem(f"{(i+1)*10:.2f}")
                 # Mark the first row as recurring for demo purposes
                 is_recurring = i == 0
@@ -190,6 +196,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     [date_item, desc_item, cat_item, amt_item]
                 ):
                     table.setItem(i, col, item)
+                table.update_row_tooltip(i)
 
             self._update_table_total(table, update_summary=False)
 
@@ -372,6 +379,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 font = QtGui.QFont(item.font())
                 font.setItalic(not current)
                 item.setFont(font)
+            table.update_row_tooltip(row)
 
     def retrain_classifier(self) -> None:
         reply = QtWidgets.QMessageBox.question(

--- a/gui/monthly_tabbed_window.py
+++ b/gui/monthly_tabbed_window.py
@@ -1,9 +1,14 @@
 from PyQt5 import QtWidgets, QtCore, QtGui
-from .navigation_table_widget import NavigationTableWidget
+from .navigation_table_widget import (
+    NavigationTableWidget,
+    ORIGINAL_DESC_ROLE,
+    CATEGORY_METHOD_ROLE,
+    IS_RECURRING_ROLE,
+)
 from datetime import datetime
 
-# Custom role used to store whether a row is marked as recurring
-IS_RECURRING_ROLE = QtCore.Qt.UserRole + 1
+# Custom role used to store whether a row is marked as recurring is imported
+# above as ``IS_RECURRING_ROLE``.
 # Role used to flag the separator row that indicates the last classified point
 SEPARATOR_ROLE = QtCore.Qt.UserRole + 2
 
@@ -26,6 +31,9 @@ class TableSection(QtWidgets.QGroupBox):
         layout.addWidget(self.total_label, alignment=QtCore.Qt.AlignRight)
 
         self.table.itemChanged.connect(self.update_total)
+        self.table.itemChanged.connect(
+            lambda item: self.table.update_row_tooltip(item.row())
+        )
 
         # Track the row index of the last classified transaction
         self.last_classified_row: int = -1
@@ -44,6 +52,7 @@ class TableSection(QtWidgets.QGroupBox):
             font = QtGui.QFont(item.font())
             font.setItalic(recurring)
             item.setFont(font)
+        self.table.update_row_tooltip(row)
 
     def toggle_selected_recurring(self) -> None:
         """Toggle the recurring flag for all selected rows."""
@@ -248,10 +257,22 @@ class MonthlyTabbedWindow(QtWidgets.QMainWindow):
                     text = src_item.text() if src_item else ""
                     item = QtWidgets.QTableWidgetItem(text)
                     item.setData(IS_RECURRING_ROLE, True)
+                    if src_item is not None:
+                        if col == 1:
+                            item.setData(
+                                ORIGINAL_DESC_ROLE,
+                                src_item.data(ORIGINAL_DESC_ROLE) or src_item.text(),
+                            )
+                        if col == 3:
+                            item.setData(
+                                CATEGORY_METHOD_ROLE,
+                                src_item.data(CATEGORY_METHOD_ROLE) or "manual",
+                            )
                     font = QtGui.QFont(item.font())
                     font.setItalic(True)
                     item.setFont(font)
                     dst_section.table.setItem(dest_row, col, item)
+                dst_section.table.update_row_tooltip(dest_row)
             dst_section.set_last_classified_row(-1)
             dst_section.update_total()
 

--- a/gui/navigation_table_widget.py
+++ b/gui/navigation_table_widget.py
@@ -1,5 +1,10 @@
 from PyQt5 import QtWidgets, QtCore, QtGui
 
+# Roles used by NavigationTableWidget to store extra data
+IS_RECURRING_ROLE = QtCore.Qt.UserRole + 1
+ORIGINAL_DESC_ROLE = QtCore.Qt.UserRole + 10
+CATEGORY_METHOD_ROLE = QtCore.Qt.UserRole + 11
+
 
 class NavigationTableWidget(QtWidgets.QTableWidget):
     """QTableWidget with simple keyboard navigation helpers."""
@@ -60,3 +65,49 @@ class NavigationTableWidget(QtWidgets.QTableWidget):
             return
 
         super().keyPressEvent(event)
+
+    # --------------------------------------------------------------
+    # Tooltip helpers
+    # --------------------------------------------------------------
+    def _find_column(self, name: str) -> int | None:
+        """Return the column index whose header matches name."""
+        for i in range(self.columnCount()):
+            header = self.horizontalHeaderItem(i)
+            if header and header.text().strip().lower() == name.lower():
+                return i
+        return None
+
+    def update_row_tooltip(self, row: int) -> None:
+        """Set a tooltip on all items in the row with extra info."""
+        desc_col = self._find_column("description")
+        if desc_col is None:
+            return
+        desc_item = self.item(row, desc_col)
+        if desc_item is None:
+            return
+        orig_desc = desc_item.data(ORIGINAL_DESC_ROLE) or desc_item.text()
+
+        cat_col = self._find_column("category")
+        method = "manual"
+        if cat_col is not None:
+            cat_item = self.item(row, cat_col)
+            if cat_item and cat_item.data(CATEGORY_METHOD_ROLE):
+                method = cat_item.data(CATEGORY_METHOD_ROLE)
+
+        recurring = False
+        for c in range(self.columnCount()):
+            item = self.item(row, c)
+            if item and item.data(IS_RECURRING_ROLE):
+                recurring = True
+                break
+
+        tooltip = (
+            f"Original: {orig_desc}\n"
+            f"Category Source: {method}\n"
+            f"Recurring: {'Yes' if recurring else 'No'}"
+        )
+        for c in range(self.columnCount()):
+            item = self.item(row, c)
+            if item:
+                item.setToolTip(tooltip)
+


### PR DESCRIPTION
## Summary
- add custom data roles and tooltip helpers to `NavigationTableWidget`
- show original description and category source when populating tables
- keep tooltips updated when toggling recurring rows and duplicating months
- use `NavigationTableWidget` in Numbers importer

## Testing
- `python -m py_compile gui/navigation_table_widget.py gui/main_window.py gui/monthly_tabbed_window.py parser/numbers_importer.py`

------
https://chatgpt.com/codex/tasks/task_e_6862f127d24c8331a93055ce215b5007