### PR TITLE
Add table footer totals

### DIFF
--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -140,8 +140,16 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.tables.append(table)
                 self.total_labels.append(total_label)
 
-                table.itemChanged.connect(
-                    lambda _item, tbl=table: self._update_table_total(tbl)
+                # Keep totals up to date as the table changes
+                table.cellChanged.connect(
+                    lambda _r, _c, tbl=table: self._update_table_total(tbl)
+                )
+                model = table.model()
+                model.rowsInserted.connect(
+                    lambda *_args, tbl=table: self._update_table_total(tbl)
+                )
+                model.rowsRemoved.connect(
+                    lambda *_args, tbl=table: self._update_table_total(tbl)
                 )
 
         # Bottom action buttons

--- a/gui/monthly_tabbed_window.py
+++ b/gui/monthly_tabbed_window.py
@@ -32,9 +32,12 @@ class TableSection(QtWidgets.QGroupBox):
         self.total_label = QtWidgets.QLabel("Total: 0.00")
         layout.addWidget(self.total_label, alignment=QtCore.Qt.AlignRight)
 
-        self.table.itemChanged.connect(self.update_total)
-        self.table.itemChanged.connect(
-            lambda item: self.table.update_row_tooltip(item.row())
+        # Keep the total label in sync with table edits
+        self.table.cellChanged.connect(lambda _r, _c: self.update_total())
+        self.table.model().rowsInserted.connect(lambda *_: self.update_total())
+        self.table.model().rowsRemoved.connect(lambda *_: self.update_total())
+        self.table.cellChanged.connect(
+            lambda r, _c: self.table.update_row_tooltip(r)
         )
 
         # Track the row index of the last classified transaction
@@ -165,7 +168,13 @@ class MonthlyTab(QtWidgets.QWidget):
             self.sections.append(section)
             # Show a separator at the top by default
             section.set_last_classified_row(-1)
-            section.table.itemChanged.connect(self.update_summary)
+            section.table.cellChanged.connect(lambda *_: self.update_summary())
+            section.table.model().rowsInserted.connect(
+                lambda *_: self.update_summary()
+            )
+            section.table.model().rowsRemoved.connect(
+                lambda *_: self.update_summary()
+            )
 
         self.summary = SummarySection()
         layout.addWidget(self.summary)

--- a/parser/numbers_importer.py
+++ b/parser/numbers_importer.py
@@ -107,8 +107,16 @@ def create_numbers_layout(data: Dict[str, Any]) -> QtWidgets.QTabWidget:
             # Apply tooltip after all items are set
             table.update_row_tooltip(r)
 
-        table.itemChanged.connect(
-            lambda _item, tbl=table, lbl=total_label: _update_total(tbl, lbl)
+        # Recalculate totals whenever the table content changes
+        table.cellChanged.connect(
+            lambda _r, _c, tbl=table, lbl=total_label: _update_total(tbl, lbl)
+        )
+        model = table.model()
+        model.rowsInserted.connect(
+            lambda *_args, tbl=table, lbl=total_label: _update_total(tbl, lbl)
+        )
+        model.rowsRemoved.connect(
+            lambda *_args, tbl=table, lbl=total_label: _update_total(tbl, lbl)
         )
         _update_total(table, total_label)
 


### PR DESCRIPTION
## Summary
- keep total labels in sync using `cellChanged`, `rowsInserted`, and `rowsRemoved`
- update TableSection, MonthlyTab, MainWindow, and Numbers importer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f3487a1c83318e5006bb6716caef