### PR TITLE
Add CSV export for monthly summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Personal Financial Analysis is a desktop application for tracking and analysing 
 - Summary dashboard tab with pie and bar charts
 - Basic admin tools for editing keyword mappings used during categorisation
 - Simple password-protected login screen (configured via `.env`)
+- Export the monthly summary to a CSV file
 
 
 ## Demo Mode


### PR DESCRIPTION
## Summary
- add `Export` button in monthly summary UI
- export monthly totals to `exports/summary_<MONTH>.csv`
- mention export feature in README

## Testing
- `python -m py_compile gui/monthly_tabbed_window.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f5f2c0c48331ba9defdaf26ef497