### PR TITLE
Add admin mappings tab

### DIFF
--- a/demo/demo_finance.sql
+++ b/demo/demo_finance.sql
@@ -33,6 +33,8 @@ INSERT INTO categories VALUES(3,'Investments','expense');
 CREATE TABLE mappings (
     id INTEGER PRIMARY KEY,
     keyword TEXT NOT NULL,
+    min_amount REAL NOT NULL,
+    max_amount REAL NOT NULL,
     category_id INTEGER,
     recurring_guess INTEGER DEFAULT 0,
     last_used TEXT,

--- a/schema.sql
+++ b/schema.sql
@@ -33,6 +33,8 @@ CREATE TABLE IF NOT EXISTS categories (
 CREATE TABLE IF NOT EXISTS mappings (
     id INTEGER PRIMARY KEY,
     keyword TEXT NOT NULL,
+    min_amount REAL NOT NULL,
+    max_amount REAL NOT NULL,
     category_id INTEGER,
     recurring_guess INTEGER DEFAULT 0,
     last_used TEXT,


### PR DESCRIPTION
## Summary
- expand admin view with new 'Mappings' tab
- display mapping ranges and categories in a table
- allow editing, deletion and saving of mappings
- support min/max columns in DB schema

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862f5ebb1d883319e2ec89e05639709