### PR TITLE
Add inactivity lock to PyQt5 UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Personal Financial Analysis is a desktop application for tracking and analysing 
 - Summary dashboard tab with pie and bar charts
 - Basic admin tools for editing keyword mappings used during categorisation
 - Simple password-protected login screen (configured via `.env`)
+- Automatic screen lock after 10 minutes of inactivity
 - Automatic database backups after each batch of transaction classifications
 - Export the monthly summary to a CSV file
 

--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -6,6 +6,7 @@ from .monthly_tabbed_window import MonthlyTabbedWindow
 from .dashboard_tab import DashboardTab
 from .recurring_tab import RecurringTab
 from .navigation_table_widget import NavigationTableWidget
+from .inactivity import InactivityFilter, UnlockDialog
 
 __all__ = [
     "MainWindow",
@@ -14,4 +15,6 @@ __all__ = [
     "DashboardTab",
     "RecurringTab",
     "NavigationTableWidget",
+    "InactivityFilter",
+    "UnlockDialog",
 ]

--- a/gui/inactivity.py
+++ b/gui/inactivity.py
@@ -1,0 +1,55 @@
+from PyQt5 import QtWidgets, QtCore
+import hashlib
+
+
+class UnlockDialog(QtWidgets.QDialog):
+    """Simple password dialog displayed when the screen is locked."""
+
+    def __init__(self, password_hash: str) -> None:
+        super().__init__()
+        self.setWindowTitle("Unlock")
+        self._hash = password_hash
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(QtWidgets.QLabel("Enter password to unlock:"))
+        self.edit = QtWidgets.QLineEdit()
+        self.edit.setEchoMode(QtWidgets.QLineEdit.Password)
+        layout.addWidget(self.edit)
+        btn = QtWidgets.QPushButton("Unlock")
+        layout.addWidget(btn)
+        btn.clicked.connect(self._check)
+
+    def _check(self) -> None:
+        text = self.edit.text()
+        if hashlib.sha256(text.encode()).hexdigest() == self._hash:
+            self.accept()
+        else:
+            QtWidgets.QMessageBox.warning(self, "Error", "Incorrect password")
+
+
+class InactivityFilter(QtCore.QObject):
+    """Event filter that locks the screen after a period of inactivity."""
+
+    def __init__(self, password_hash: str, timeout_ms: int = 600_000) -> None:
+        super().__init__()
+        self._hash = password_hash
+        self._timer = QtCore.QTimer(self)
+        self._timer.setInterval(timeout_ms)
+        self._timer.setSingleShot(True)
+        self._timer.timeout.connect(self._lock)
+        self._timer.start()
+
+    def eventFilter(self, obj: QtCore.QObject, event: QtCore.QEvent) -> bool:  # type: ignore[override]
+        if event.type() in (
+            QtCore.QEvent.MouseMove,
+            QtCore.QEvent.MouseButtonPress,
+            QtCore.QEvent.KeyPress,
+            QtCore.QEvent.Wheel,
+        ):
+            self._timer.start()
+        return False
+
+    def _lock(self) -> None:
+        dlg = UnlockDialog(self._hash)
+        dlg.exec_()
+        self._timer.start()

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from dotenv import dotenv_values
 import hashlib
 import os
 
-from gui import LoginWindow
+from gui import LoginWindow, InactivityFilter
 
 
 def main():
@@ -42,6 +42,8 @@ def main():
             f.write(f"PASSWORD_HASH={password_hash}\n")
 
     login = LoginWindow()
+    inactivity = InactivityFilter(password_hash)
+    app.installEventFilter(inactivity)
     login.show()
     app.exec_()
 


### PR DESCRIPTION
## Summary
- add new `InactivityFilter` that locks the UI after 10 minutes of inactivity
- expose new GUI utilities in package init
- hook inactivity filter in `main.py`
- document the new feature in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862f7c209048331b346fd48b2db339c