### PR TITLE
Improve text contrast

### DIFF
--- a/gui/login_window.py
+++ b/gui/login_window.py
@@ -1,4 +1,4 @@
-from PyQt5 import QtWidgets
+from PyQt5 import QtWidgets, QtGui
 import hashlib
 from dotenv import dotenv_values
 
@@ -27,6 +27,15 @@ class LoginWindow(QtWidgets.QWidget):
         self.password_edit = QtWidgets.QLineEdit()
         self.password_edit.setEchoMode(QtWidgets.QLineEdit.Password)
         self.password_edit.setPlaceholderText("Enter password")
+        # Ensure password text and placeholder use dark text on light background
+        self.password_edit.setStyleSheet(
+            "color: #111; background-color: white;"
+        )
+        pal = self.password_edit.palette()
+        pal.setColor(QtGui.QPalette.Text, QtGui.QColor("#111"))
+        pal.setColor(QtGui.QPalette.Base, QtGui.QColor("white"))
+        pal.setColor(QtGui.QPalette.PlaceholderText, QtGui.QColor("#111"))
+        self.password_edit.setPalette(pal)
         layout.addWidget(self.password_edit)
 
         self.login_btn = QtWidgets.QPushButton("Login")

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -63,6 +63,8 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Top tab bar
         self.tab_bar = QtWidgets.QTabBar(movable=False)
+        # Ensure tab text is dark for readability
+        self.tab_bar.setStyleSheet("QTabBar::tab{color:#111;}")
         self.tabs = ["Income", "Expenses", "Credit Card", "Summary", "Admin"]
         for tab in self.tabs:
             self.tab_bar.addTab(tab)

--- a/gui/monthly_tabbed_window.py
+++ b/gui/monthly_tabbed_window.py
@@ -256,6 +256,8 @@ class MonthlyTabbedWindow(QtWidgets.QMainWindow):
             layout.addWidget(banner)
 
         self.tabs = QtWidgets.QTabWidget()
+        # Tab labels in dark text for high contrast
+        self.tabs.tabBar().setStyleSheet("QTabBar::tab{color:#111;}")
         layout.addWidget(self.tabs)
         self.setCentralWidget(main_widget)
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 """Application entry point for Personal Financial Analysis."""
 
 from PyQt5 import QtWidgets
+from PyQt5 import QtGui
 from dotenv import dotenv_values
 import hashlib
 import os
@@ -16,6 +17,25 @@ def main():
     if os.path.exists(qss_path):
         with open(qss_path) as fh:
             app.setStyleSheet(fh.read())
+
+    # Global palette to ensure high contrast dark text on light backgrounds
+    palette = app.palette()
+    dark = QtGui.QColor("#111")
+    light = QtGui.QColor("white")
+    for role in (
+        QtGui.QPalette.WindowText,
+        QtGui.QPalette.Text,
+        QtGui.QPalette.ButtonText,
+        QtGui.QPalette.ToolTipText,
+        QtGui.QPalette.PlaceholderText,
+    ):
+        palette.setColor(role, dark)
+    for role in (
+        QtGui.QPalette.Window,
+        QtGui.QPalette.Base,
+    ):
+        palette.setColor(role, light)
+    app.setPalette(palette)
 
     config = dotenv_values(".env")
     password_hash = config.get("PASSWORD_HASH")

--- a/style.qss
+++ b/style.qss
@@ -3,6 +3,7 @@
 /* Light grey background for widgets */
 QWidget {
     background: #f9f9f9;
+    color: #111;
 }
 
 /* Rounded group boxes */
@@ -21,7 +22,7 @@ QGroupBox::title {
 /* Table header styling */
 QHeaderView::section {
     font-weight: bold;
-    color: #0078d7;
+    color: #111;
     background: #eaeaea;
     padding: 4px;
     border: 1px solid #d0d0d0;
@@ -33,6 +34,7 @@ QTableWidget {
     alternating-row-colors: true;
     background: #ffffff;
     alternate-background-color: #f2f2f2;
+    color: #111;
 }
 
 /* Hover and selection highlighting for table rows */
@@ -47,4 +49,9 @@ QTableWidget::item:selected {
 QTableWidget QTableCornerButton::section {
     border: 1px solid #d0d0d0;
     background: #eaeaea;
+}
+
+/* Dark text for tabs */
+QTabBar::tab {
+    color: #111;
 }


### PR DESCRIPTION
## Summary
- darken tab and table text colors for high contrast
- ensure login password field uses dark text and placeholder
- set dark app palette and style tabs

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862faced8d4833184e77406491ee9fa