### PR TITLE
Implement DataTableSection with SQLite hooks

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -3,6 +3,7 @@
 from .main_window import MainWindow
 from .login_window import LoginWindow
 from .monthly_tabbed_window import MonthlyTabbedWindow
+from .data_table_section import DataTableSection
 from .dashboard_tab import DashboardTab
 from .recurring_tab import RecurringTab
 from .navigation_table_widget import NavigationTableWidget
@@ -23,4 +24,5 @@ __all__ = [
     "AmountDelegate",
     "DateDelegate",
     "CategoryDelegate",
+    "DataTableSection",
 ]

--- a/gui/data_table_section.py
+++ b/gui/data_table_section.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import sqlite3
+from PyQt5 import QtWidgets, QtCore
+
+from .monthly_tabbed_window import TableSection
+from logic.month_manager import DB_PATH, _ensure_db
+
+
+class DataTableSection(TableSection):
+    """TableSection connected to the SQLite backend."""
+
+    TABLE_NAME = "monthly_entries"
+
+    def __init__(self, title: str, key: str, month: str) -> None:
+        super().__init__(title)
+        self.key = key
+        self.month = month
+        self.table.itemChanged.connect(self._item_changed)
+        self.table.model().rowsInserted.connect(self._rows_inserted)
+        self.table.model().rowsRemoved.connect(self._rows_removed)
+        self._load_data()
+
+    # ------------------------------------------------------------------
+    # Database helpers
+    # ------------------------------------------------------------------
+    def _get_conn(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(DB_PATH)
+        conn.row_factory = sqlite3.Row
+        _ensure_db(conn)
+        conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {self.TABLE_NAME} (
+                id INTEGER PRIMARY KEY,
+                month TEXT NOT NULL,
+                table_key TEXT NOT NULL,
+                date TEXT,
+                description TEXT,
+                amount REAL,
+                category TEXT,
+                notes TEXT
+            )
+            """
+        )
+        return conn
+
+    def _load_data(self) -> None:
+        conn = self._get_conn()
+        cur = conn.execute(
+            f"SELECT id, date, description, amount, category, notes FROM {self.TABLE_NAME} "
+            "WHERE month = ? AND table_key = ? ORDER BY id",
+            (self.month, self.key),
+        )
+        rows = cur.fetchall()
+        conn.close()
+        self.table.blockSignals(True)
+        for row in rows:
+            idx = self.manager.add_row([
+                row["date"] or "",
+                row["description"] or "",
+                f"{row['amount']:.2f}" if row["amount"] is not None else "",
+                row["category"] or "",
+                row["notes"] or "",
+            ])
+            for col in range(self.table.columnCount()):
+                item = self.table.item(idx, col)
+                if item:
+                    item.setData(QtCore.Qt.UserRole, row["id"])
+        self.table.blockSignals(False)
+        self.update_total()
+
+    # ------------------------------------------------------------------
+    # Row helpers
+    # ------------------------------------------------------------------
+    def _row_values(self, row: int) -> tuple[str, str, float, str, str]:
+        def txt(col: int) -> str:
+            item = self.table.item(row, col)
+            return item.text().strip() if item else ""
+
+        date = txt(0)
+        desc = txt(1)
+        amt_str = txt(2)
+        try:
+            amt = float(amt_str)
+        except ValueError:
+            amt = 0.0
+        cat = txt(3)
+        notes = txt(4)
+        return date, desc, amt, cat, notes
+
+    def _insert_row(self, row: int) -> None:
+        date, desc, amt, cat, notes = self._row_values(row)
+        conn = self._get_conn()
+        cur = conn.execute(
+            f"INSERT INTO {self.TABLE_NAME} (month, table_key, date, description, amount, category, notes) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (self.month, self.key, date, desc, amt, cat, notes),
+        )
+        row_id = cur.lastrowid
+        conn.commit()
+        conn.close()
+        for col in range(self.table.columnCount()):
+            item = self.table.item(row, col)
+            if item:
+                item.setData(QtCore.Qt.UserRole, row_id)
+
+    # ------------------------------------------------------------------
+    # Slots
+    # ------------------------------------------------------------------
+    def _rows_inserted(self, parent: QtCore.QModelIndex, start: int, end: int) -> None:  # noqa: D401 - Qt slot
+        for row in range(start, end + 1):
+            self._insert_row(row)
+
+    def _item_changed(self, row: int, _col: int) -> None:  # noqa: D401 - Qt slot
+        item = self.table.item(row, 0)
+        if not item:
+            return
+        row_id = item.data(QtCore.Qt.UserRole)
+        if row_id is None:
+            self._insert_row(row)
+            return
+        date, desc, amt, cat, notes = self._row_values(row)
+        conn = self._get_conn()
+        conn.execute(
+            f"UPDATE {self.TABLE_NAME} SET date = ?, description = ?, amount = ?, category = ?, notes = ? WHERE id = ?",
+            (date, desc, amt, cat, notes, row_id),
+        )
+        conn.commit()
+        conn.close()
+        self.update_total()
+
+    def _rows_removed(self, parent: QtCore.QModelIndex, start: int, end: int) -> None:  # noqa: D401 - Qt slot
+        conn = self._get_conn()
+        for row in range(start, end + 1):
+            id_item = self.table.item(row, 0)
+            if id_item is None:
+                continue
+            row_id = id_item.data(QtCore.Qt.UserRole)
+            if row_id is not None:
+                conn.execute(
+                    f"DELETE FROM {self.TABLE_NAME} WHERE id = ?",
+                    (row_id,),
+                )
+        conn.commit()
+        conn.close()
+
+
+__all__ = ["DataTableSection"]

--- a/gui/monthly_tabbed_window.py
+++ b/gui/monthly_tabbed_window.py
@@ -97,6 +97,9 @@ class TableSection(QtWidgets.QGroupBox):
         self.manager.update_total()
 
 
+from .data_table_section import DataTableSection
+
+
 class SummarySection(QtWidgets.QGroupBox):
     """Panel showing monthly totals."""
 
@@ -197,14 +200,25 @@ class MonthlyTab(QtWidgets.QMainWindow):
             self.addDockWidget(area, dock)
             return dock
 
-        income_section = TableSection("Income Table")
-        expenses_section = TableSection("Expenses Table")
-        self.sections = [income_section, expenses_section]
+        sections_info = [
+            ("Income Table", "income"),
+            ("Expenses Table", "expenses"),
+            ("Withdrawals Table", "withdrawals"),
+            ("Assets Table", "assets"),
+            ("Liabilities Table", "liabilities"),
+            ("Provisions Table", "provisions"),
+            ("Credit Card Classifier Table", "credit_card"),
+            ("Cash at Month End Table", "cash_end"),
+            ("Cash Crosscheck Table", "cash_crosscheck"),
+            ("Net Worth Table", "net_worth"),
+            ("Asset Allocation Table", "asset_allocation"),
+        ]
+
+        self.sections = [DataTableSection(title, key, self.month_name) for title, key in sections_info]
         for section in self.sections:
             section.set_last_classified_row(-1)
 
-        networth_section = TableSection("Net Worth")
-        liabilities_section = TableSection("Liabilities")
+        income_section = self.sections[0]
 
         passive_group = QtWidgets.QGroupBox("Passive Income")
         passive_layout = QtWidgets.QVBoxLayout(passive_group)
@@ -216,9 +230,6 @@ class MonthlyTab(QtWidgets.QMainWindow):
         income_section.table.model().rowsInserted.connect(lambda *_: self.update_passive_chart())
         income_section.table.model().rowsRemoved.connect(lambda *_: self.update_passive_chart())
 
-        cash_end_section = TableSection("Cash at Month End")
-        crosscheck_section = TableSection("Cash Crosscheck")
-
         aa_chart_group = QtWidgets.QGroupBox("Asset Allocation Pie Charts")
         aa_chart_layout = QtWidgets.QHBoxLayout(aa_chart_group)
         self.target_fig = Figure(figsize=(3, 3))
@@ -228,21 +239,26 @@ class MonthlyTab(QtWidgets.QMainWindow):
         aa_chart_layout.addWidget(self.target_canvas)
         aa_chart_layout.addWidget(self.actual_canvas)
 
-        asset_table_section = TableSection("Asset Allocation Table")
-        provisions_section = TableSection("Provisions Table")
-        cc_classifier_section = TableSection("Credit Card Classifier Table")
+        dock_map = {
+            "Income Table": QtCore.Qt.LeftDockWidgetArea,
+            "Expenses Table": QtCore.Qt.LeftDockWidgetArea,
+            "Withdrawals Table": QtCore.Qt.LeftDockWidgetArea,
+            "Assets Table": QtCore.Qt.LeftDockWidgetArea,
+            "Liabilities Table": QtCore.Qt.LeftDockWidgetArea,
+            "Net Worth Table": QtCore.Qt.LeftDockWidgetArea,
+            "Provisions Table": QtCore.Qt.RightDockWidgetArea,
+            "Credit Card Classifier Table": QtCore.Qt.RightDockWidgetArea,
+            "Cash at Month End Table": QtCore.Qt.RightDockWidgetArea,
+            "Cash Crosscheck Table": QtCore.Qt.RightDockWidgetArea,
+            "Asset Allocation Table": QtCore.Qt.RightDockWidgetArea,
+        }
 
-        make_dock("Income", income_section, QtCore.Qt.LeftDockWidgetArea)
-        make_dock("Expenses", expenses_section, QtCore.Qt.LeftDockWidgetArea)
-        make_dock("Net Worth", networth_section, QtCore.Qt.LeftDockWidgetArea)
-        make_dock("Liabilities", liabilities_section, QtCore.Qt.LeftDockWidgetArea)
         make_dock("Passive Income", passive_group, QtCore.Qt.RightDockWidgetArea)
-        make_dock("Cash End", cash_end_section, QtCore.Qt.RightDockWidgetArea)
-        make_dock("Cash Crosscheck", crosscheck_section, QtCore.Qt.RightDockWidgetArea)
         make_dock("Asset Allocation Charts", aa_chart_group, QtCore.Qt.RightDockWidgetArea)
-        make_dock("Asset Allocation Table", asset_table_section, QtCore.Qt.RightDockWidgetArea)
-        make_dock("Provisions Table", provisions_section, QtCore.Qt.RightDockWidgetArea)
-        make_dock("Credit Card Classifier", cc_classifier_section, QtCore.Qt.RightDockWidgetArea)
+
+        for section in self.sections:
+            area = dock_map.get(section.title(), QtCore.Qt.RightDockWidgetArea)
+            make_dock(section.title().replace("Table", "").strip(), section, area)
 
         self._load_layout()
 
@@ -481,6 +497,7 @@ __all__ = [
     "MonthlyTabbedWindow",
     "MonthlyTab",
     "TableSection",
+    "DataTableSection",
     "SummarySection",
     "RecurringTab",
 ]

--- a/schema.sql
+++ b/schema.sql
@@ -49,3 +49,15 @@ CREATE TABLE IF NOT EXISTS import_logs (
     type TEXT NOT NULL
 );
 
+-- Generic entries table used by monthly data sections
+CREATE TABLE IF NOT EXISTS monthly_entries (
+    id INTEGER PRIMARY KEY,
+    month TEXT NOT NULL,
+    table_key TEXT NOT NULL,
+    date TEXT,
+    description TEXT,
+    amount REAL,
+    category TEXT,
+    notes TEXT
+);
+


### PR DESCRIPTION
## Summary
- add new `DataTableSection` class to manage tables with SQLite CRUD
- expose `DataTableSection` in `gui/__init__`
- extend `MonthlyTab` to build all monthly tables using `DataTableSection`
- persist data in new `monthly_entries` table in `schema.sql`

## Testing
- `python -m py_compile gui/data_table_section.py gui/monthly_tabbed_window.py`
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6863037fef988331a28537749dcfaa8c