### PR TITLE
Add synced QScrollAreas example

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -10,6 +10,7 @@ from .navigation_table_widget import NavigationTableWidget
 from .table_manager import TransactionTableManager
 from .delegates import AmountDelegate, DateDelegate, CategoryDelegate
 from .inactivity import InactivityFilter, UnlockDialog
+from .synced_splitter import SyncedSplitter
 
 __all__ = [
     "MainWindow",
@@ -25,4 +26,5 @@ __all__ = [
     "DateDelegate",
     "CategoryDelegate",
     "DataTableSection",
+    "SyncedSplitter",
 ]

--- a/gui/synced_splitter.py
+++ b/gui/synced_splitter.py
@@ -1,0 +1,48 @@
+from PyQt5 import QtWidgets, QtCore
+
+
+class SyncedSplitter(QtWidgets.QWidget):
+    """Demo widget showing two synced scroll areas in a splitter."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        layout = QtWidgets.QHBoxLayout(self)
+        splitter = QtWidgets.QSplitter()
+        layout.addWidget(splitter)
+
+        self.left_area = QtWidgets.QScrollArea()
+        self.left_area.setWidgetResizable(True)
+        self.left_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
+
+        self.right_area = QtWidgets.QScrollArea()
+        self.right_area.setWidgetResizable(True)
+        self.right_area.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
+
+        splitter.addWidget(self.left_area)
+        splitter.addWidget(self.right_area)
+
+        # Populate left and right scroll areas with sample content
+        left_widget = QtWidgets.QWidget()
+        left_layout = QtWidgets.QVBoxLayout(left_widget)
+        for i in range(30):
+            left_layout.addWidget(QtWidgets.QLabel(f"Left item {i + 1}"))
+        left_layout.addStretch()
+        self.left_area.setWidget(left_widget)
+
+        right_widget = QtWidgets.QWidget()
+        right_layout = QtWidgets.QVBoxLayout(right_widget)
+        for i in range(30):
+            right_layout.addWidget(QtWidgets.QLabel(f"Right item {i + 1}"))
+        right_layout.addStretch()
+        self.right_area.setWidget(right_widget)
+
+        # Sync the vertical scroll bars so both areas stay aligned
+        self.left_area.verticalScrollBar().valueChanged.connect(
+            self.right_area.verticalScrollBar().setValue
+        )
+        self.right_area.verticalScrollBar().valueChanged.connect(
+            self.left_area.verticalScrollBar().setValue
+        )
+
+
+__all__ = ["SyncedSplitter"]


### PR DESCRIPTION
## Summary
- add SyncedSplitter widget demonstrating two QScrollAreas in a QSplitter
- export SyncedSplitter from `gui/__init__.py`

## Testing
- `python -m py_compile gui/synced_splitter.py`
- `python -m py_compile gui/__init__.py gui/synced_splitter.py`

------
https://chatgpt.com/codex/tasks/task_e_68630875d3388331b177ec9611f31eba