### PR TITLE
Add runtime demo mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Personal Financial Analysis is a desktop application for tracking and analysing 
 ## Demo Mode
 
 The project ships with a small set of safe example data in the `demo/` folder.
-Set `DEMO_MODE=true` in the `.env` file to run the application using the demo
-CSV and database. If `demo/demo_finance.db` is missing the application will
-create it automatically from `demo/demo_finance.sql`.
+Set `DEMO_MODE=true` in the `.env` file to start in demo mode or toggle it at
+runtime from the **View → Toggle Demo Mode** menu option. When enabled the
+application uses the demo CSV and database. If `demo/demo_finance.db` is missing
+it will be created automatically from `demo/demo_finance.sql`.
 
 ## Installation
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,19 @@
+import os
+import sqlite3
+
+BASE_DIR = os.path.dirname(__file__)
+DEMO_MODE = os.getenv("DEMO_MODE", "false").lower() == "true"
+
+
+def get_db_path() -> str:
+    """Return path to the active database, creating demo DB if needed."""
+    if DEMO_MODE:
+        path = os.path.join(BASE_DIR, "demo", "demo_finance.db")
+        if not os.path.exists(path):
+            sql_path = os.path.join(BASE_DIR, "demo", "demo_finance.sql")
+            conn = sqlite3.connect(path)
+            with open(sql_path, "r", encoding="utf-8") as f:
+                conn.executescript(f.read())
+            conn.close()
+        return path
+    return os.path.join(BASE_DIR, "data", "finance.db")

--- a/gui/dashboard_tab.py
+++ b/gui/dashboard_tab.py
@@ -7,7 +7,8 @@ import sqlite3
 from datetime import datetime
 import calendar
 
-from logic.month_manager import DB_PATH, _ensure_db
+from logic.month_manager import _ensure_db
+from config import get_db_path
 
 
 class DashboardTab(QtWidgets.QWidget):
@@ -34,7 +35,8 @@ class DashboardTab(QtWidgets.QWidget):
     # Database helpers
     # ------------------------------------------------------------------
     def _get_conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(DB_PATH)
+        db_path = get_db_path()
+        conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
         _ensure_db(conn)
         return conn

--- a/gui/data_table_section.py
+++ b/gui/data_table_section.py
@@ -4,7 +4,8 @@ import sqlite3
 from PyQt5 import QtWidgets, QtCore
 
 from .monthly_tabbed_window import TableSection
-from logic.month_manager import DB_PATH, _ensure_db
+from logic.month_manager import _ensure_db
+from config import get_db_path
 
 
 class DataTableSection(TableSection):
@@ -25,7 +26,8 @@ class DataTableSection(TableSection):
     # Database helpers
     # ------------------------------------------------------------------
     def _get_conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(DB_PATH)
+        db_path = get_db_path()
+        conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
         _ensure_db(conn)
         conn.execute(

--- a/gui/delegates.py
+++ b/gui/delegates.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from PyQt5 import QtWidgets, QtCore, QtGui
 import sqlite3
 
-from logic.month_manager import DB_PATH, _ensure_db
+from logic.month_manager import _ensure_db
+from config import get_db_path
 
 
 class AmountDelegate(QtWidgets.QStyledItemDelegate):
@@ -48,7 +49,8 @@ class CategoryDelegate(QtWidgets.QStyledItemDelegate):
     """Delegate providing a dropdown of categories."""
 
     def _categories(self):
-        conn = sqlite3.connect(DB_PATH)
+        db_path = get_db_path()
+        conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
         _ensure_db(conn)
         cur = conn.execute("SELECT name FROM categories ORDER BY name")

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -11,7 +11,8 @@ IS_RECURRING_ROLE = QtCore.Qt.UserRole + 1
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 import sqlite3
-from logic.categoriser import DB_PATH, _ensure_db
+from logic.categoriser import _ensure_db
+from config import get_db_path
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -289,7 +290,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.canvas.draw()
 
     def _get_conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(DB_PATH)
+        db_path = get_db_path()
+        conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
         _ensure_db(conn)
         return conn

--- a/gui/monthly_tabbed_window.py
+++ b/gui/monthly_tabbed_window.py
@@ -1,7 +1,6 @@
 from PyQt5 import QtWidgets, QtCore, QtGui
-import os
 
-DEMO_MODE = os.getenv("DEMO_MODE", "false").lower() == "true"
+from config import DEMO_MODE
 import pandas as pd
 from .navigation_table_widget import (
     NavigationTableWidget,
@@ -451,9 +450,26 @@ class MonthlyTabbedWindow(QtWidgets.QMainWindow):
         super().__init__()
         self.setWindowTitle("Personal Financial Analysis")
         self.resize(1000, 700)
+        self.demo_mode = DEMO_MODE
+        self._create_menu()
         months = months or self._generate_default_months()
         self._setup_ui(months)
         self.current_month = months[0]
+
+    def _create_menu(self) -> None:
+        menubar = self.menuBar()
+        view_menu = menubar.addMenu("View")
+        self.demo_action = QtWidgets.QAction("Toggle Demo Mode", self, checkable=True)
+        self.demo_action.setChecked(self.demo_mode)
+        self.demo_action.triggered.connect(self._toggle_demo_mode)
+        view_menu.addAction(self.demo_action)
+
+    def _toggle_demo_mode(self, checked: bool) -> None:
+        self.demo_mode = checked
+        import config
+        config.DEMO_MODE = checked
+        self.demo_banner.setVisible(checked)
+        self.demo_action.setChecked(checked)
 
     def _generate_default_months(self):
         """Return a list of upcoming months for the sidebar."""
@@ -464,13 +480,13 @@ class MonthlyTabbedWindow(QtWidgets.QMainWindow):
     def _setup_ui(self, months) -> None:
         main_widget = QtWidgets.QWidget()
         layout = QtWidgets.QVBoxLayout(main_widget)
-        if DEMO_MODE:
-            banner = QtWidgets.QLabel("DEMO MODE ACTIVE")
-            banner.setAlignment(QtCore.Qt.AlignCenter)
-            banner.setStyleSheet(
-                "background-color: #c00; color: white; font-weight: bold; padding: 4px;"
-            )
-            layout.addWidget(banner)
+        self.demo_banner = QtWidgets.QLabel("DEMO MODE ACTIVE")
+        self.demo_banner.setAlignment(QtCore.Qt.AlignCenter)
+        self.demo_banner.setStyleSheet(
+            "background-color: #c00; color: white; font-weight: bold; padding: 4px;"
+        )
+        layout.addWidget(self.demo_banner)
+        self.demo_banner.setVisible(self.demo_mode)
 
         # Central stacked area for monthly views
         self.month_stack = QtWidgets.QStackedWidget()

--- a/gui/recurring_tab.py
+++ b/gui/recurring_tab.py
@@ -4,7 +4,8 @@ from PyQt5 import QtWidgets, QtCore
 import sqlite3
 from datetime import datetime
 
-from logic.month_manager import DB_PATH, _ensure_db
+from logic.month_manager import _ensure_db
+from config import get_db_path
 from .navigation_table_widget import NavigationTableWidget
 
 
@@ -41,7 +42,8 @@ class RecurringTab(QtWidgets.QWidget):
     # Database helpers
     # ------------------------------------------------------------------
     def _get_conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(DB_PATH)
+        db_path = get_db_path()
+        conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
         _ensure_db(conn)
         return conn

--- a/logic/month_manager.py
+++ b/logic/month_manager.py
@@ -6,16 +6,7 @@ import os
 import sqlite3
 from datetime import datetime
 
-DEMO_MODE = os.getenv("DEMO_MODE", "false").lower() == "true"
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-DB_PATH = os.path.join(BASE_DIR, "demo", "demo_finance.db") if DEMO_MODE else os.path.join(BASE_DIR, "data", "finance.db")
-
-if DEMO_MODE and not os.path.exists(DB_PATH):
-    sql_path = os.path.join(BASE_DIR, "demo", "demo_finance.sql")
-    conn = sqlite3.connect(DB_PATH)
-    with open(sql_path, "r", encoding="utf-8") as f:
-        conn.executescript(f.read())
-    conn.close()
+from config import BASE_DIR, get_db_path
 SCHEMA_PATH = os.path.join(BASE_DIR, "schema.sql")
 
 
@@ -35,7 +26,7 @@ def duplicate_previous_month(
     name: str,
     start_date: str,
     end_date: str,
-    db_path: str = DB_PATH,
+    db_path: str | None = None,
 ) -> int:
     """Create a new month by duplicating the last month's recurring transactions.
 
@@ -45,6 +36,7 @@ def duplicate_previous_month(
     reset implicitly as no balances are carried over.
     """
 
+    db_path = db_path or get_db_path()
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     _ensure_db(conn)

--- a/parser/csv_importer.py
+++ b/parser/csv_importer.py
@@ -10,17 +10,9 @@ from typing import List, Dict, Any, Optional
 
 import pandas as pd
 
-DEMO_MODE = os.getenv("DEMO_MODE", "false").lower() == "true"
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-ARCHIVE_DIR = os.path.join(BASE_DIR, "archived")
-DB_PATH = os.path.join(BASE_DIR, "demo", "demo_finance.db") if DEMO_MODE else os.path.join(BASE_DIR, "data", "finance.db")
+from config import BASE_DIR, get_db_path
 
-if DEMO_MODE and not os.path.exists(DB_PATH):
-    sql_path = os.path.join(BASE_DIR, "demo", "demo_finance.sql")
-    conn = sqlite3.connect(DB_PATH)
-    with open(sql_path, "r", encoding="utf-8") as f:
-        conn.executescript(f.read())
-    conn.close()
+ARCHIVE_DIR = os.path.join(BASE_DIR, "archived")
 
 
 def _find_column(columns: List[str], names: List[str]) -> Optional[str]:
@@ -85,7 +77,8 @@ def _archive(file_path: str, file_type: str) -> None:
     archived_path = os.path.join(ARCHIVE_DIR, archived_name)
     os.replace(file_path, archived_path)
 
-    conn = sqlite3.connect(DB_PATH)
+    db_path = get_db_path()
+    conn = sqlite3.connect(db_path)
     conn.execute(
         "CREATE TABLE IF NOT EXISTS import_logs (id INTEGER PRIMARY KEY, file_name TEXT, date TEXT, type TEXT)"
     )

--- a/parser/pdf_importer.py
+++ b/parser/pdf_importer.py
@@ -10,17 +10,9 @@ from typing import List, Dict, Any
 
 import pdfplumber
 
-DEMO_MODE = os.getenv("DEMO_MODE", "false").lower() == "true"
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-ARCHIVE_DIR = os.path.join(BASE_DIR, "archived")
-DB_PATH = os.path.join(BASE_DIR, "demo", "demo_finance.db") if DEMO_MODE else os.path.join(BASE_DIR, "data", "finance.db")
+from config import BASE_DIR, get_db_path
 
-if DEMO_MODE and not os.path.exists(DB_PATH):
-    sql_path = os.path.join(BASE_DIR, "demo", "demo_finance.sql")
-    conn = sqlite3.connect(DB_PATH)
-    with open(sql_path, "r", encoding="utf-8") as f:
-        conn.executescript(f.read())
-    conn.close()
+ARCHIVE_DIR = os.path.join(BASE_DIR, "archived")
 
 PATTERN = re.compile(
     r"(?P<date>\d{1,2}[/-]\d{1,2}[/-]\d{2,4})\s+(?P<desc>.*?)\s+(?P<amt>-?\$?[\d,]+\.\d{2})$"
@@ -59,7 +51,8 @@ def _archive(file_path: str, file_type: str) -> None:
     archived_path = os.path.join(ARCHIVE_DIR, archived_name)
     os.replace(file_path, archived_path)
 
-    conn = sqlite3.connect(DB_PATH)
+    db_path = get_db_path()
+    conn = sqlite3.connect(db_path)
     conn.execute(
         "CREATE TABLE IF NOT EXISTS import_logs (id INTEGER PRIMARY KEY, file_name TEXT, date TEXT, type TEXT)"
     )


### PR DESCRIPTION
## Summary
- introduce `config.py` for shared DEMO_MODE flag and DB path helper
- update modules to use `get_db_path()` instead of hardcoded DB_PATH
- add demo mode toggle in `MonthlyTabbedWindow` with checkbox menu item
- show banner only when demo mode is active
- document new toggle in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68636f080d948331a552f815d398f264