### PR TITLE
Fix MonthlyTab base class

### DIFF
--- a/gui/monthly_tabbed_window.py
+++ b/gui/monthly_tabbed_window.py
@@ -195,7 +195,7 @@ class SummarySection(QtWidgets.QGroupBox):
 
 
 
-class MonthlyTab(QtWidgets.QWidget):
+class MonthlyTab(QtWidgets.QMainWindow):
     """Monthly view with draggable sections inside a scroll area."""
 
     def __init__(self, month_name: str) -> None:


### PR DESCRIPTION
## Summary
- fix the `MonthlyTab` base class so docking methods exist

## Testing
- `python -m py_compile gui/monthly_tabbed_window.py`
- `python main.py` *(fails: ModuleNotFoundError: No module named 'PyQt5')*

------
https://chatgpt.com/codex/tasks/task_e_6863942b05648331ba564e38bd54e644