### PR TITLE
Fix layout deletion in tabbed window

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -2,5 +2,6 @@
 
 from .main_window import MainWindow
 from .login_window import LoginWindow
+from .monthly_tabbed_window import MonthlyTabbedWindow
 
-__all__ = ["MainWindow", "LoginWindow"]
+__all__ = ["MainWindow", "LoginWindow", "MonthlyTabbedWindow"]

--- a/gui/monthly_tabbed_window.py
+++ b/gui/monthly_tabbed_window.py
@@ -1,0 +1,50 @@
+from PyQt5 import QtWidgets
+import sip
+
+class ReorderableScrollArea(QtWidgets.QScrollArea):
+    """Scroll area that exposes its container and layout."""
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        container = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
+        self.setWidget(container)
+        self.setWidgetResizable(True)
+
+        # store references to prevent premature deletion
+        self.container = container
+        self._layout = layout
+
+class MonthlyTab(QtWidgets.QWidget):
+    """A tab containing reorderable sections for a month."""
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        # create scroll area before any sections are added
+        self.area = ReorderableScrollArea(self)
+        self.container = self.area.container
+        self._layout = self.area._layout
+
+        outer_layout = QtWidgets.QVBoxLayout(self)
+        outer_layout.addWidget(self.area)
+
+    def add_section(self, widget: QtWidgets.QWidget) -> None:
+        """Add a new section widget to the tab."""
+        if sip.isdeleted(self._layout):
+            print("Skipped add_section: layout has been deleted.")
+            return
+        self._layout.addWidget(widget)
+
+class MonthlyTabbedWindow(QtWidgets.QMainWindow):
+    """Main window showing a tab of monthly sections."""
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(central)
+        self.monthly_tab = MonthlyTab()
+        layout.addWidget(self.monthly_tab)
+        self.setCentralWidget(central)
+
+        # keep references so layout/container persist
+        self._central_container = central
+        self._central_layout = layout


### PR DESCRIPTION
## Summary
- add new `MonthlyTabbedWindow` module
- expose scroll area container and layout as persistent attributes
- guard against layout deletion in `add_section`
- export the new window from the GUI package

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687217f1ae408331b3c86a5c79ed97f4