### PR TITLE
Add data import panel

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -3,5 +3,11 @@
 from .main_window import MainWindow
 from .login_window import LoginWindow
 from .monthly_tabbed_window import MonthlyTabbedWindow
+from .data_import_panel import DataImportPanel
 
-__all__ = ["MainWindow", "LoginWindow", "MonthlyTabbedWindow"]
+__all__ = [
+    "MainWindow",
+    "LoginWindow",
+    "MonthlyTabbedWindow",
+    "DataImportPanel",
+]

--- a/gui/data_import_panel.py
+++ b/gui/data_import_panel.py
@@ -1,0 +1,72 @@
+from PyQt5 import QtWidgets
+import os
+import sqlite3
+
+from parser import parse_csv
+from logic.categoriser import DB_PATH, _ensure_db
+
+
+class DataImportPanel(QtWidgets.QWidget):
+    """Widget for uploading and importing CSV/Numbers files."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QtWidgets.QVBoxLayout(self)
+
+        self.upload_btn = QtWidgets.QPushButton("Upload CSVs or Numbers Exports")
+        self.upload_btn.clicked.connect(self.select_files)
+        layout.addWidget(self.upload_btn)
+
+        self.file_list = QtWidgets.QListWidget()
+        layout.addWidget(self.file_list)
+
+        self.import_btn = QtWidgets.QPushButton("Import Files")
+        self.import_btn.clicked.connect(self.import_files)
+        layout.addWidget(self.import_btn)
+
+        self.selected_files = []
+
+    def select_files(self) -> None:
+        paths, _ = QtWidgets.QFileDialog.getOpenFileNames(
+            self,
+            "Select Files",
+            "",
+            "CSV or Numbers (*.csv *.numbers)",
+        )
+        if paths:
+            self.selected_files = paths
+            self.file_list.clear()
+            for p in paths:
+                self.file_list.addItem(os.path.basename(p))
+
+    def import_files(self) -> None:
+        if not self.selected_files:
+            return
+        conn = sqlite3.connect(DB_PATH)
+        conn.row_factory = sqlite3.Row
+        _ensure_db(conn)
+        for path in self.selected_files:
+            try:
+                transactions = parse_csv(path)
+            except Exception as exc:
+                QtWidgets.QMessageBox.warning(
+                    self,
+                    "Import Error",
+                    f"Failed to parse {os.path.basename(path)}:\n{exc}",
+                )
+                continue
+            for tx in transactions:
+                tx_type = "income" if tx["amount"] >= 0 else "expense"
+                conn.execute(
+                    "INSERT INTO transactions (date, description, amount, type) VALUES (?, ?, ?, ?)",
+                    (tx["date"], tx["description"], tx["amount"], tx_type),
+                )
+        conn.commit()
+        conn.close()
+        QtWidgets.QMessageBox.information(self, "Import", "Files imported successfully")
+        self.selected_files = []
+        self.file_list.clear()
+
+
+__all__ = ["DataImportPanel"]
+

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -3,6 +3,7 @@ from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 import sqlite3
 from logic.categoriser import DB_PATH, _ensure_db
+from .data_import_panel import DataImportPanel
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -55,7 +56,14 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Top tab bar
         self.tab_bar = QtWidgets.QTabBar(movable=False)
-        self.tabs = ["Income", "Expenses", "Credit Card", "Summary", "Admin"]
+        self.tabs = [
+            "Income",
+            "Expenses",
+            "Credit Card",
+            "Summary",
+            "Admin",
+            "Data Import",
+        ]
         for tab in self.tabs:
             self.tab_bar.addTab(tab)
         self.tab_bar.currentChanged.connect(self.switch_tab)
@@ -114,6 +122,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
                 self.stack.addWidget(admin_widget)
                 self.admin_widget = admin_widget
+            elif tab == "Data Import":
+                import_widget = DataImportPanel()
+                self.stack.addWidget(import_widget)
+                self.import_widget = import_widget
             else:
                 table = QtWidgets.QTableWidget(0, 4)
                 table.setHorizontalHeaderLabels(


### PR DESCRIPTION
## Summary
- add `DataImportPanel` widget with upload/import buttons
- expose `DataImportPanel` in `gui.__init__`
- mount the new panel from a `Data Import` top-level tab

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6872196ebfe48331b8346a523e19c7ba