### PR TITLE
Fix login image path and remove asset

### DIFF
--- a/gui/login_window.py
+++ b/gui/login_window.py
@@ -1,4 +1,5 @@
-from PyQt5 import QtWidgets
+import os
+from PyQt5 import QtWidgets, QtGui, QtCore
 import hashlib
 from dotenv import dotenv_values
 
@@ -11,7 +12,7 @@ class LoginWindow(QtWidgets.QWidget):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("Personal Financial Analysis – Login")
-        self.setStyleSheet("background-color: lightblue;")
+        self.setStyleSheet("background-color: #ffffff; color: #000000;")
         self._load_password_hash()
         self._setup_ui()
         self.main_window = None
@@ -23,13 +24,37 @@ class LoginWindow(QtWidgets.QWidget):
 
     def _setup_ui(self):
         layout = QtWidgets.QVBoxLayout(self)
+        layout.setSpacing(20)
+        layout.setAlignment(QtCore.Qt.AlignCenter)
+
+        self.image_label = QtWidgets.QLabel()
+        img_path = os.path.join(os.path.dirname(__file__), "..", "welcome.png")
+        pixmap = QtGui.QPixmap(img_path)
+        if not pixmap.isNull():
+            pixmap = pixmap.scaledToWidth(300, QtCore.Qt.SmoothTransformation)
+            self.image_label.setPixmap(pixmap)
+        else:
+            self.image_label.setText("Welcome image not found.")
+        self.image_label.setAlignment(QtCore.Qt.AlignCenter)
+        layout.addWidget(self.image_label)
+
+        self.welcome_label = QtWidgets.QLabel("Welcome James")
+        self.welcome_label.setAlignment(QtCore.Qt.AlignCenter)
+        self.welcome_label.setStyleSheet("font-size: 18px;")
+        layout.addWidget(self.welcome_label)
 
         self.password_edit = QtWidgets.QLineEdit()
         self.password_edit.setEchoMode(QtWidgets.QLineEdit.Password)
         self.password_edit.setPlaceholderText("Enter password")
+        self.password_edit.setStyleSheet(
+            "background-color: #ffffff; color: #000000; padding: 4px;"
+        )
         layout.addWidget(self.password_edit)
 
         self.login_btn = QtWidgets.QPushButton("Login")
+        self.login_btn.setStyleSheet(
+            "background-color: #dddddd; color: #000000; padding: 4px;"
+        )
         self.login_btn.clicked.connect(self.check_password)
         layout.addWidget(self.login_btn)
 


### PR DESCRIPTION
## Summary
- remove welcome.png binary asset
- load welcome.png relative to the module and display fallback text if missing

## Testing
- `python -m py_compile gui/login_window.py`


------
https://chatgpt.com/codex/tasks/task_e_68721caaaa4c8331a12e6e6e18a87434