### PR TITLE
Add overview charts

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -3,11 +3,13 @@
 from .main_window import MainWindow
 from .login_window import LoginWindow
 from .monthly_tabbed_window import MonthlyTabbedWindow
+from .overview_section import OverviewSection
 from .data_import_panel import DataImportPanel
 
 __all__ = [
     "MainWindow",
     "LoginWindow",
     "MonthlyTabbedWindow",
+    "OverviewSection",
     "DataImportPanel",
 ]

--- a/gui/monthly_tabbed_window.py
+++ b/gui/monthly_tabbed_window.py
@@ -1,6 +1,8 @@
 from PyQt5 import QtWidgets
 import sip
 
+from .overview_section import OverviewSection
+
 class ReorderableScrollArea(QtWidgets.QScrollArea):
     """Scroll area that exposes its container and layout."""
     def __init__(self, parent=None):
@@ -25,15 +27,22 @@ class MonthlyTab(QtWidgets.QWidget):
         self.container = self.area.container
         self._layout = self.area._layout
 
+        self.overview = OverviewSection()
+        self._layout.addWidget(self.overview)
+
         outer_layout = QtWidgets.QVBoxLayout(self)
         outer_layout.addWidget(self.area)
-
+        
     def add_section(self, widget: QtWidgets.QWidget) -> None:
         """Add a new section widget to the tab."""
         if sip.isdeleted(self._layout):
             print("Skipped add_section: layout has been deleted.")
             return
         self._layout.addWidget(widget)
+
+    def refresh_overview(self) -> None:
+        """Refresh charts in the overview section."""
+        self.overview.refresh()
 
 class MonthlyTabbedWindow(QtWidgets.QMainWindow):
     """Main window showing a tab of monthly sections."""
@@ -48,3 +57,7 @@ class MonthlyTabbedWindow(QtWidgets.QMainWindow):
         # keep references so layout/container persist
         self._central_container = central
         self._central_layout = layout
+
+    def refresh_overview(self) -> None:
+        """Refresh charts for the current month."""
+        self.monthly_tab.refresh_overview()

--- a/gui/overview_section.py
+++ b/gui/overview_section.py
@@ -1,0 +1,79 @@
+from PyQt5 import QtWidgets
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
+import sqlite3
+from logic.categoriser import DB_PATH, _ensure_db
+
+class OverviewSection(QtWidgets.QWidget):
+    """Widget showing passive income and asset allocation charts."""
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        layout = QtWidgets.QHBoxLayout(self)
+
+        self.passive_fig = Figure(figsize=(4, 3))
+        self.passive_canvas = FigureCanvas(self.passive_fig)
+        layout.addWidget(self.passive_canvas)
+
+        self.asset_fig = Figure(figsize=(4, 3))
+        self.asset_canvas = FigureCanvas(self.asset_fig)
+        layout.addWidget(self.asset_canvas)
+
+        layout.addStretch()
+        self.setLayout(layout)
+
+        self.refresh()
+
+    def _get_conn(self):
+        conn = sqlite3.connect(DB_PATH)
+        conn.row_factory = sqlite3.Row
+        _ensure_db(conn)
+        return conn
+
+    def refresh(self):
+        """Refresh charts using data from the database."""
+        conn = self._get_conn()
+        try:
+            # Passive income
+            cur = conn.execute(
+                """
+                SELECT description, SUM(amount) as total FROM transactions
+                WHERE (category LIKE '%Interest%' OR category LIKE '%Dividend%')
+                GROUP BY description
+                ORDER BY total DESC
+                """
+            )
+            rows = cur.fetchall()
+            labels = [row['description'] for row in rows]
+            values = [row['total'] for row in rows]
+
+            self.passive_fig.clear()
+            ax1 = self.passive_fig.add_subplot(111)
+            ax1.bar(labels, values)
+            ax1.set_ylabel('Amount')
+            ax1.set_title('Passive Income')
+            ax1.tick_params(axis='x', rotation=45)
+            self.passive_fig.tight_layout()
+            self.passive_canvas.draw()
+
+            # Asset allocation
+            cur = conn.execute(
+                "SELECT name, amount FROM assets" if self._assets_exist(conn) else "SELECT '' as name, 1 as amount"
+            )
+            rows = cur.fetchall()
+            names = [row['name'] for row in rows]
+            amounts = [row['amount'] for row in rows]
+            self.asset_fig.clear()
+            ax2 = self.asset_fig.add_subplot(111)
+            if amounts:
+                ax2.pie(amounts, labels=names, autopct='%1.1f%%')
+            ax2.set_title('Asset Allocation')
+            self.asset_fig.tight_layout()
+            self.asset_canvas.draw()
+        finally:
+            conn.close()
+
+    def _assets_exist(self, conn):
+        cur = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='assets'"
+        )
+        return cur.fetchone() is not None


### PR DESCRIPTION
## Summary
- add OverviewSection widget for side-by-side charts
- show overview charts inside MonthlyTab
- expose refresh method and export widget

## Testing
- `python -m py_compile gui/overview_section.py gui/monthly_tabbed_window.py gui/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68722206a4588331bde49bffd2e558dc