### PR TITLE
Add cashflow projection engine and forecast tab

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -6,6 +6,7 @@ from .monthly_tabbed_window import MonthlyTabbedWindow
 from .overview_section import OverviewSection
 from .data_import_panel import DataImportPanel
 from .category_manager_dialog import CategoryManagerDialog
+from .forecast_widget import ForecastWidget
 
 __all__ = [
     "MainWindow",
@@ -14,4 +15,5 @@ __all__ = [
     "OverviewSection",
     "DataImportPanel",
     "CategoryManagerDialog",
+    "ForecastWidget",
 ]

--- a/gui/forecast_widget.py
+++ b/gui/forecast_widget.py
@@ -1,0 +1,112 @@
+"""Forecast display widget."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from typing import Tuple, List
+
+from PyQt5 import QtWidgets
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
+
+from logic.projection_engine import generate_projection
+from logic.categoriser import DB_PATH, _ensure_db
+
+
+class ForecastWidget(QtWidgets.QWidget):
+    """Widget showing projected cashflow."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QtWidgets.QVBoxLayout(self)
+
+        self.table = QtWidgets.QTableWidget(0, 2)
+        self.table.setHorizontalHeaderLabels(["Category", "Projected Amount"])
+        self.table.horizontalHeader().setStretchLastSection(True)
+        layout.addWidget(self.table)
+
+        self.figure = Figure(figsize=(5, 3))
+        self.canvas = FigureCanvas(self.figure)
+        layout.addWidget(self.canvas)
+
+        self.setLayout(layout)
+
+    # ------------------------------------------------------------------
+    # Data helpers
+    # ------------------------------------------------------------------
+    def _get_conn(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(DB_PATH)
+        conn.row_factory = sqlite3.Row
+        _ensure_db(conn)
+        return conn
+
+    def _load_history(self, month_id: str) -> Tuple[List[str], List[float]]:
+        conn = self._get_conn()
+        cur = conn.execute(
+            "SELECT start_date FROM months WHERE id = ? OR name = ?",
+            (month_id, month_id),
+        )
+        row = cur.fetchone()
+        if not row:
+            conn.close()
+            return [], []
+        start_date = row["start_date"]
+        cur = conn.execute(
+            "SELECT strftime('%Y-%m', date) as ym, SUM(amount) as total "
+            "FROM transactions WHERE date < ? GROUP BY ym ORDER BY ym",
+            (start_date,),
+        )
+        rows = cur.fetchall()
+        conn.close()
+        months = [datetime.strptime(r["ym"] + "-01", "%Y-%m-%d").strftime("%b %Y") for r in rows]
+        totals = [r["total"] for r in rows]
+        return months, totals
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def refresh(self, month_id: str) -> None:
+        data = generate_projection(month_id)
+        if not data:
+            self.table.setRowCount(0)
+            self.figure.clear()
+            self.canvas.draw()
+            return
+        first = next(iter(data.values()))
+        combined = {}
+        for cat, amt in first["income"].items():
+            combined[cat] = combined.get(cat, 0.0) + amt
+        for cat, amt in first["expenses"].items():
+            combined[cat] = combined.get(cat, 0.0) - amt
+        self.table.setRowCount(len(combined))
+        for i, (cat, amt) in enumerate(combined.items()):
+            self.table.setItem(i, 0, QtWidgets.QTableWidgetItem(cat))
+            self.table.setItem(i, 1, QtWidgets.QTableWidgetItem(f"{amt:.2f}"))
+        self.table.resizeColumnsToContents()
+
+        hist_months, hist_nets = self._load_history(month_id)
+        proj_months = list(data.keys())
+        proj_nets = [d["net"] for d in data.values()]
+
+        months = hist_months + proj_months
+
+        self.figure.clear()
+        ax = self.figure.add_subplot(111)
+        if hist_months:
+            ax.plot(hist_months, hist_nets, marker="o", label="Historical")
+            proj_plot_months = [hist_months[-1]] + proj_months
+            proj_plot_vals = [hist_nets[-1]] + proj_nets
+        else:
+            proj_plot_months = proj_months
+            proj_plot_vals = proj_nets
+        ax.plot(proj_plot_months, proj_plot_vals, marker="o", label="Projected")
+        ax.set_ylabel("Net Cashflow")
+        ax.set_xticks(range(len(months)))
+        ax.set_xticklabels(months, rotation=45, ha="right")
+        ax.legend()
+        self.figure.tight_layout()
+        self.canvas.draw()
+
+
+__all__ = ["ForecastWidget"]

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -7,6 +7,7 @@ import sqlite3
 from logic.categoriser import DB_PATH, _ensure_db
 from .data_import_panel import DataImportPanel
 from .category_manager_dialog import CategoryManagerDialog
+from .forecast_widget import ForecastWidget
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -73,6 +74,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.month_dock.setWidget(self.month_list)
         self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, self.month_dock)
         self.month_list.currentTextChanged.connect(self.load_dummy_data)
+        self.month_list.currentTextChanged.connect(self.update_forecast)
         if not self.sidebar_visible:
             self.month_dock.hide()
 
@@ -96,6 +98,7 @@ class MainWindow(QtWidgets.QMainWindow):
             "Expenses",
             "Credit Card",
             "Summary",
+            "Forecast",
             "Admin",
             "Data Import",
         ]
@@ -129,6 +132,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
                 self.stack.addWidget(summary_widget)
                 self.summary_widget = summary_widget
+            elif tab == "Forecast":
+                forecast_widget = ForecastWidget()
+                self.stack.addWidget(forecast_widget)
+                self.forecast_widget = forecast_widget
             elif tab == "Admin":
                 admin_widget = QtWidgets.QWidget()
                 admin_layout = QtWidgets.QVBoxLayout(admin_widget)
@@ -195,6 +202,8 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Initialize with dummy data for the first month
         self.month_list.setCurrentRow(0)
+        if self.month_list.currentItem() is not None:
+            self.update_forecast(self.month_list.currentItem().text())
 
     def switch_tab(self, index: int):
         self.stack.setCurrentIndex(index)
@@ -219,6 +228,12 @@ class MainWindow(QtWidgets.QMainWindow):
                     table.setItem(i, col, item)
 
         self._update_summary()
+        self.update_forecast(month)
+
+    def update_forecast(self, month: str) -> None:
+        """Refresh projection display for the selected month."""
+        if hasattr(self, "forecast_widget"):
+            self.forecast_widget.refresh(month)
 
     def _update_summary(self) -> None:
         """Update the summary table and chart."""

--- a/logic/projection_engine.py
+++ b/logic/projection_engine.py
@@ -1,0 +1,119 @@
+"""Cashflow projection utilities."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime
+from typing import Dict, Any
+
+DEMO_MODE = os.getenv("DEMO_MODE", "false").lower() == "true"
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+DB_PATH = (
+    os.path.join(BASE_DIR, "demo", "demo_finance.db")
+    if DEMO_MODE
+    else os.path.join(BASE_DIR, "data", "finance.db")
+)
+SCHEMA_PATH = os.path.join(BASE_DIR, "schema.sql")
+
+if DEMO_MODE and not os.path.exists(DB_PATH):
+    sql_path = os.path.join(BASE_DIR, "demo", "demo_finance.sql")
+    conn = sqlite3.connect(DB_PATH)
+    with open(sql_path, "r", encoding="utf-8") as f:
+        conn.executescript(f.read())
+    conn.close()
+
+
+def _ensure_db(conn: sqlite3.Connection) -> None:
+    """Ensure required tables exist."""
+    with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+        conn.executescript(f.read())
+
+
+def _add_months(date_str: str, months: int) -> datetime:
+    dt = datetime.strptime(date_str, "%Y-%m-%d")
+    year = dt.year + (dt.month - 1 + months) // 12
+    month = (dt.month - 1 + months) % 12 + 1
+    return dt.replace(year=year, month=month, day=1)
+
+
+def generate_projection(month_id: str, months_ahead: int = 3) -> Dict[str, Any]:
+    """Return cashflow projection for the next ``months_ahead`` months."""
+    if months_ahead <= 0:
+        return {}
+
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    _ensure_db(conn)
+
+    cur = conn.execute(
+        "SELECT start_date FROM months WHERE id = ? OR name = ?",
+        (month_id, month_id),
+    )
+    row = cur.fetchone()
+    if not row:
+        conn.close()
+        raise ValueError(f"Month {month_id} not found")
+    start_date = row["start_date"]
+
+    # Average monthly totals for non-recurring transactions
+    cur = conn.execute(
+        """
+        SELECT c.name AS category, t.type, AVG(month_total) AS avg_amount
+        FROM (
+            SELECT category, type, strftime('%Y-%m', date) AS ym,
+                   SUM(amount) AS month_total
+            FROM transactions
+            WHERE date < ? AND (is_recurring = 0 OR is_recurring IS NULL)
+            GROUP BY category, type, ym
+        ) t
+        LEFT JOIN categories c ON t.category = c.id
+        GROUP BY t.category, t.type
+        """,
+        (start_date,),
+    )
+    averages = {"income": {}, "expense": {}}
+    for r in cur.fetchall():
+        cat = r["category"] or "Uncategorised"
+        amt = r["avg_amount"] or 0.0
+        averages[r["type"]][cat] = abs(amt)
+
+    # Recurring transactions averaged separately
+    cur = conn.execute(
+        """
+        SELECT c.name AS category, type, AVG(amount) AS avg_amount
+        FROM transactions
+        LEFT JOIN categories c ON category = c.id
+        WHERE is_recurring = 1 AND date < ?
+        GROUP BY category, type
+        """,
+        (start_date,),
+    )
+    for r in cur.fetchall():
+        cat = r["category"] or "Uncategorised"
+        amt = r["avg_amount"] or 0.0
+        averages[r["type"]].setdefault(cat, 0.0)
+        averages[r["type"]][cat] += abs(amt)
+
+    projection: Dict[str, Any] = {}
+    base_dt = datetime.strptime(start_date, "%Y-%m-%d")
+    for i in range(1, months_ahead + 1):
+        m_dt = _add_months(start_date, i)
+        label = m_dt.strftime("%b %Y")
+        incomes = averages.get("income", {}).copy()
+        expenses = averages.get("expense", {}).copy()
+        total_income = sum(incomes.values())
+        total_expense = sum(expenses.values())
+        net = total_income - total_expense
+        projection[label] = {
+            "income": incomes,
+            "expenses": expenses,
+            "net": net,
+            "negative": net < 0,
+        }
+
+    conn.close()
+    return projection
+
+
+__all__ = ["generate_projection"]


### PR DESCRIPTION
## Summary
- implement a simple projection engine calculating average monthly income and expenses
- add a forecast widget showing projected cashflow and history
- integrate forecast tab into the main window

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68722fadc4348331af4ab1e7e1b37975